### PR TITLE
Minor change to mergedb to no longer merge over OS version

### DIFF
--- a/cmd/mergedb/main.go
+++ b/cmd/mergedb/main.go
@@ -54,6 +54,7 @@ func main() {
 			// Don't automatically merge across these values
 			if !(r1.UASignature.BrowserName == r2.UASignature.BrowserName &&
 				r1.UASignature.OSName == r2.UASignature.OSName &&
+				r1.UASignature.OSVersion == r2.UASignature.OSVersion &&
 				r1.UASignature.DeviceType == r2.UASignature.DeviceType &&
 				r1.UASignature.Quirk.String() == r2.UASignature.Quirk.String() &&
 				r1.RequestSignature.Version.String() == r2.RequestSignature.Version.String() &&


### PR DESCRIPTION
Hi there! This is a tiny PR :) I noticed that we were merging over operating system version, which often produces large fingerprints. Given that operating systems and their cryptography can often substantially vary across versions, I thought it would be useful to not merge fingerprints over operating system versions to maintain some granularity in their fingerprints. 

Let me know what you think. With the changes I made here, our merged new fingerprints still continued to pass the tests I wrote in #4. 