### PR TITLE
optimize sets

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -146,6 +146,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6bb2e1cbcf253307a88a531a75aa4d38fecb8d56a0dc9e837e288fe3189954f6"
+  name = "golang.org/x/tools"
+  packages = ["container/intsets"]
+  pruneopts = "UT"
+  revision = "4c874b978acba4ecd4a257d3bb8829dd5de17be8"
+
+[[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -161,6 +169,7 @@
     "github.com/goamz/goamz/aws",
     "github.com/goamz/goamz/s3",
     "github.com/spf13/viper",
+    "golang.org/x/tools/container/intsets",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/mergedb/main.go
+++ b/cmd/mergedb/main.go
@@ -69,10 +69,10 @@ func main() {
 				return true
 			}
 			// Do not merge if the merged signature is too lenient
-			if merged.Cipher.OrderedList == nil && len(merged.Cipher.OptionalSet) > 10 {
+			if merged.Cipher.OrderedList == nil && merged.Cipher.OptionalSet.Len() > 10 {
 				return false
 			}
-			if merged.Extension.OrderedList == nil && len(merged.Extension.OptionalSet) > 10 {
+			if merged.Extension.OrderedList == nil && merged.Extension.OptionalSet.Len() > 10 {
 				return false
 			}
 			return true

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -48,9 +48,9 @@ func TestDatabaseGetByUAFingerprint(t *testing.T) {
 		{fp.UAFingerprint{BrowserName: 2}, []uint64(nil)},
 	}
 	a, _ := db.NewDatabase(bytes.NewReader(nil))
-	a.Add(db.Record{UASignature: fp.UASignature{
-		BrowserName: 1,
-	}})
+	var record db.Record
+	record.Parse("1:0:0:0:0:0:|::::::|::")
+	a.Add(record)
 	for _, test := range tests {
 		testutil.Equals(t, test.out, a.GetByUAFingerprint(test.in))
 	}
@@ -62,13 +62,13 @@ func TestDatabaseGetByRequestFingerprint(t *testing.T) {
 		out []uint64
 	}{
 		{fp.RequestFingerprint{}, []uint64(nil)},
-		{fp.RequestFingerprint{Version: 1}, []uint64{0}},
+		{fp.RequestFingerprint{Version: fp.VersionTLS12}, []uint64{0}},
 		{fp.RequestFingerprint{Version: 2}, []uint64(nil)},
 	}
 	a, _ := db.NewDatabase(bytes.NewReader(nil))
-	a.Add(db.Record{RequestSignature: fp.RequestSignature{
-		Version: fp.VersionSignature{Exp: 1, Min: 1, Max: 1},
-	}})
+	var record db.Record
+	record.Parse("1:0:0:0:0:0:|303::::::|::")
+	a.Add(record)
 	for _, test := range tests {
 		testutil.Equals(t, test.out, a.GetByRequestFingerprint(test.in))
 	}

--- a/fputil/collection.go
+++ b/fputil/collection.go
@@ -110,10 +110,7 @@ func (a *IntSet) List() IntList {
 
 // Copy sets the value of IntSet a to the value of IntSet b.
 func (a *IntSet) Copy(b *IntSet) {
-	fmt.Println("in copy, a is", a)
-	fmt.Println("in copy, b is", b)
 	if a != nil && b != nil {
-		fmt.Println("copying!")
 		a.Sparse.Copy(&b.Sparse)
 	}
 }

--- a/fputil/collection_test.go
+++ b/fputil/collection_test.go
@@ -95,10 +95,10 @@ func TestIntListEquals(t *testing.T) {
 func TestIntListSet(t *testing.T) {
 	var tests = []struct {
 		in  fp.IntList
-		out fp.IntSet
+		out *fp.IntSet
 	}{
-		{fp.IntList{0}, fp.IntSet{0: true}},
-		{fp.IntList{1, 2, 3}, fp.IntSet{1: true, 2: true, 3: true}},
+		{fp.IntList{0}, fp.IntList{0}.Set()},
+		{fp.IntList{1, 2, 3}, fp.IntList{1, 2, 3}.Set()},
 	}
 
 	for _, test := range tests {
@@ -110,11 +110,12 @@ func TestIntListSet(t *testing.T) {
 // Test IntSet
 func TestIntSetList(t *testing.T) {
 	var tests = []struct {
-		in  fp.IntSet
+		in  *fp.IntSet
 		out fp.IntList
 	}{
-		{fp.IntSet{0: true}, fp.IntList{0}},
-		{fp.IntSet{1: true, 2: true, 3: true}, fp.IntList{1, 2, 3}},
+		{fp.IntList{}.Set(),fp.IntList{}},
+		{fp.IntList{0}.Set(), fp.IntList{0}},
+		{fp.IntList{1, 2, 3}.Set(), fp.IntList{1, 2, 3}},
 	}
 
 	for _, test := range tests {
@@ -125,49 +126,58 @@ func TestIntSetList(t *testing.T) {
 
 func TestIntSetInter(t *testing.T) {
 	var tests = []struct {
-		a   fp.IntSet
-		b   fp.IntSet
-		out fp.IntSet
+		a   *fp.IntSet
+		b   *fp.IntSet
+		out *fp.IntSet
 	}{
-		{fp.IntSet{0: true}, fp.IntSet{0: true}, fp.IntSet{0: true}},
-		{fp.IntSet{1: true, 2: true, 3: true}, fp.IntSet{2: true, 3: true, 4: true}, fp.IntSet{2: true, 3: true}},
+		{fp.IntList{}.Set(), fp.IntList{}.Set(), fp.IntList{}.Set()},
+		{fp.IntList{0}.Set(), fp.IntList{0}.Set(), fp.IntList{0}.Set()},
+		{fp.IntList{1, 2, 3}.Set(), fp.IntList{2, 3, 4}.Set(), fp.IntList{2, 3}.Set()},
 	}
 
 	for _, test := range tests {
 		actual := test.a.Inter(test.b)
-		testutil.Equals(t, test.out, actual)
+		// Use Equal function for sets, defined for intset.Sparse; deep equals (as defined in package testutil)
+		// does not handle intset.Sparse correctly
+		test.out.Equals(&actual.Sparse)
 	}
 }
 
 func TestIntSetDiff(t *testing.T) {
 	var tests = []struct {
-		a   fp.IntSet
-		b   fp.IntSet
-		out fp.IntSet
+		a   *fp.IntSet
+		b   *fp.IntSet
+		out *fp.IntSet
 	}{
-		{fp.IntSet{0: true}, fp.IntSet{0: true}, fp.IntSet{}},
-		{fp.IntSet{1: true, 2: true, 3: true}, fp.IntSet{2: true, 3: true, 4: true}, fp.IntSet{1: true}},
+		{fp.IntList{}.Set(), fp.IntList{}.Set(), fp.IntList{}.Set()},
+		{fp.IntList{0}.Set(), fp.IntList{0}.Set(), fp.IntList{}.Set()},
+		{fp.IntList{1, 2, 3}.Set(), fp.IntList{2, 3, 4}.Set(), fp.IntList{1}.Set()},
 	}
 
 	for _, test := range tests {
 		actual := test.a.Diff(test.b)
-		testutil.Equals(t, test.out, actual)
+		// Use Equal function for sets, defined for intset.Sparse; deep equals (as defined in package testutil)
+		// does not handle intset.Sparse correctly
+		test.out.Equals(&actual.Sparse)
 	}
 }
 
 func TestIntSetUnion(t *testing.T) {
 	var tests = []struct {
-		a   fp.IntSet
-		b   fp.IntSet
-		out fp.IntSet
+		a   *fp.IntSet
+		b   *fp.IntSet
+		out *fp.IntSet
 	}{
-		{fp.IntSet{0: true}, fp.IntSet{0: true}, fp.IntSet{0: true}},
-		{fp.IntSet{1: true, 2: true, 3: true}, fp.IntSet{2: true, 3: true, 4: true}, fp.IntSet{1: true, 2: true, 3: true, 4: true}},
+		{fp.IntList{}.Set(), fp.IntList{}.Set(), fp.IntList{}.Set()},
+		{fp.IntList{0}.Set(), fp.IntList{0}.Set(), fp.IntList{0}.Set()},
+		{fp.IntList{1, 2, 3}.Set(), fp.IntList{2, 3, 4}.Set(), fp.IntList{1, 2, 3, 4}.Set()},
 	}
 
 	for _, test := range tests {
 		actual := test.a.Union(test.b)
-		testutil.Equals(t, test.out, actual)
+		// Use Equal function for sets, defined for intset.Sparse; deep equals (as defined in package testutil)
+		// does not handle intset.Sparse correctly
+		test.out.Equals(&actual.Sparse)
 	}
 }
 

--- a/fputil/request.go
+++ b/fputil/request.go
@@ -748,6 +748,8 @@ func (a VersionSignature) Match(version Version) Match {
 // is possible with an unlikely configuration, and MatchPossible otherwise.
 func (a IntSignature) Match(list IntList) (Match, int) {
 	set := list.Set()
+
+	// Compute number of overlapping values between a and set to use as a "best match" metric if no exact match
 	similarity := set.Inter(a.RequiredSet).Len() + set.Inter(a.OptionalSet).Len()
 
 	// check if the ordered list matches
@@ -783,6 +785,7 @@ func (a IntSignature) Match(list IntList) (Match, int) {
 // is possible with an unlikely configuration, and MatchPossible otherwise.
 func (a StringSignature) Match(list StringList) Match {
 	set := list.Set()
+
 	// check if the ordered list matches
 	if a.OrderedList != nil && !a.OrderedList.Contains(list) {
 		return MatchImpossible

--- a/fputil/request_test.go
+++ b/fputil/request_test.go
@@ -1,7 +1,6 @@
 package fp_test
 
 import (
-	"fmt"
 	"testing"
 
 	fp "github.com/cloudflare/mitmengine/fputil"
@@ -145,15 +144,11 @@ func TestIntSignatureMerge(t *testing.T) {
 		{"1,2", "3,2,1", "~1,2,?3"},
 		{"1,2", "3,1,2", "?3,1,2"},
 	}
-	for i, test := range tests {
-		fmt.Println("TEST", i)
+	for _, test := range tests {
 		signature1, err := fp.NewIntSignature(test.in1)
 		testutil.Ok(t, err)
 		signature2, err := fp.NewIntSignature(test.in2)
 		testutil.Ok(t, err)
-		fmt.Printf("signature1 is %s\n", signature1.ExcludedSet.String())
-		fmt.Printf("signature2 is %s\n", signature2.ExcludedSet.String())
-		//fmt.Printf("merged is %s\n", signature1.Merge(signature2).String())
 		testutil.Equals(t, test.out, signature1.Merge(signature2).String())
 	}
 }
@@ -255,7 +250,8 @@ func TestIntSignatureMatch(t *testing.T) {
 		testutil.Ok(t, err)
 		fingerprint, err := fp.NewIntList(test.in2)
 		testutil.Ok(t, err)
-		testutil.Equals(t, test.out, signature.Match(fingerprint))
+		match, _ := signature.Match(fingerprint)
+		testutil.Equals(t, test.out, match)
 	}
 }
 

--- a/fputil/request_test.go
+++ b/fputil/request_test.go
@@ -1,6 +1,7 @@
 package fp_test
 
 import (
+	"fmt"
 	"testing"
 
 	fp "github.com/cloudflare/mitmengine/fputil"
@@ -9,7 +10,7 @@ import (
 
 var (
 	emptyVersionSig = fp.VersionSignature{}
-	emptyIntSig     = fp.IntSignature{fp.IntList{}, make(fp.IntSet), make(fp.IntSet), make(fp.IntSet), make(fp.IntSet)}
+	emptyIntSig     = fp.IntSignature{fp.IntList{}, &fp.IntSet{}, &fp.IntSet{}, &fp.IntSet{}, &fp.IntSet{}}
 	emptyStringSig  = fp.StringSignature{
 		OrderedList: fp.StringList{},
 		OptionalSet: make(fp.StringSet),
@@ -112,6 +113,7 @@ func TestRequestSignatureMerge(t *testing.T) {
 	}
 }
 
+// todo fill this function out
 func TestVersionSignatureMerge(t *testing.T) {
 	var tests = []struct {
 		in1 string
@@ -143,11 +145,15 @@ func TestIntSignatureMerge(t *testing.T) {
 		{"1,2", "3,2,1", "~1,2,?3"},
 		{"1,2", "3,1,2", "?3,1,2"},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
+		fmt.Println("TEST", i)
 		signature1, err := fp.NewIntSignature(test.in1)
 		testutil.Ok(t, err)
 		signature2, err := fp.NewIntSignature(test.in2)
 		testutil.Ok(t, err)
+		fmt.Printf("signature1 is %s\n", signature1.ExcludedSet.String())
+		fmt.Printf("signature2 is %s\n", signature2.ExcludedSet.String())
+		//fmt.Printf("merged is %s\n", signature1.Merge(signature2).String())
 		testutil.Equals(t, test.out, signature1.Merge(signature2).String())
 	}
 }

--- a/processor.go
+++ b/processor.go
@@ -194,19 +194,19 @@ func (a *Processor) Check(uaFingerprint fp.UAFingerprint, rawUa string,
 	case matchMap["cipher"] == fp.MatchImpossible:
 		r.BrowserSignatureMatch = fp.MatchImpossible
 		reason = append(reason, "invalid_cipher")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Cipher, actualReqFin.Cipher))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Cipher, actualReqFin.Cipher.String()))
 	case matchMap["extension"] == fp.MatchImpossible:
 		r.BrowserSignatureMatch = fp.MatchImpossible
 		reason = append(reason, "invalid_extension")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Extension, actualReqFin.Extension))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Extension, actualReqFin.Extension.String()))
 	case matchMap["curve"] == fp.MatchImpossible:
 		r.BrowserSignatureMatch = fp.MatchImpossible
 		reason = append(reason, "invalid_curve")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Curve, actualReqFin.Curve))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Curve, actualReqFin.Curve.String()))
 	case matchMap["ecpointfmt"] == fp.MatchImpossible:
 		r.BrowserSignatureMatch = fp.MatchImpossible
 		reason = append(reason, "invalid_ecpointfmt")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.EcPointFmt, actualReqFin.EcPointFmt))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.EcPointFmt, actualReqFin.EcPointFmt.String()))
 	case matchMap["header"] == fp.MatchImpossible:
 		r.BrowserSignatureMatch = fp.MatchImpossible
 		reason = append(reason, "invalid_header")
@@ -223,19 +223,19 @@ func (a *Processor) Check(uaFingerprint fp.UAFingerprint, rawUa string,
 	case matchMap["cipher"] == fp.MatchUnlikely:
 		r.BrowserSignatureMatch = fp.MatchUnlikely
 		reason = append(reason, "unlikely_cipher")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Cipher, actualReqFin.Cipher))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Cipher, actualReqFin.Cipher.String()))
 	case matchMap["extension"] == fp.MatchUnlikely:
 		r.BrowserSignatureMatch = fp.MatchUnlikely
 		reason = append(reason, "unlikely_extension")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Extension, actualReqFin.Extension))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Extension, actualReqFin.Extension.String()))
 	case matchMap["curve"] == fp.MatchUnlikely:
 		r.BrowserSignatureMatch = fp.MatchUnlikely
 		reason = append(reason, "unlikely_curve")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Curve, actualReqFin.Curve))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.Curve, actualReqFin.Curve.String()))
 	case matchMap["ecpointfmt"] == fp.MatchUnlikely:
 		r.BrowserSignatureMatch = fp.MatchUnlikely
 		reason = append(reason, "unlikely_ecpointfmt")
-		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.EcPointFmt, actualReqFin.EcPointFmt))
+		reasonDetails = append(reasonDetails, fmt.Sprintf("%s vs %s", browserReqSig.EcPointFmt, actualReqFin.EcPointFmt.String()))
 	case matchMap["header"] == fp.MatchUnlikely:
 		r.BrowserSignatureMatch = fp.MatchUnlikely
 		reason = append(reason, "unlikely_header")

--- a/processor_test.go
+++ b/processor_test.go
@@ -28,7 +28,8 @@ func TestProcessorConfigFile(t *testing.T) {
 		BadHeaderFileName: filepath.Join("testdata", "mitmengine", "badheader.txt"),
 	}
 	t.Run("New", func(t *testing.T) { _, err := mitmengine.NewProcessor(&testConfigFile); testutil.Ok(t, err) })
-	t.Run("Check", func(t *testing.T) { _TestProcessorCheck(t, &testConfigFile) })
+	t.Run("CheckSequential", func(t *testing.T) { _TestProcessorCheckSequential(t, &testConfigFile) })
+	t.Run("CheckConcurrent", func(t *testing.T) { _TestProcessorCheckConcurrent(t, &testConfigFile) })
 	t.Run("GetByUASignatureBrowser", func(t *testing.T) { _TestProcessorGetByUASignatureBrowser(t, &testConfigFile) })
 	t.Run("GetByRequestSignatureMitm", func(t *testing.T) { _TestProcessorGetByRequestSignatureMitm(t, &testConfigFile) })
 	//t.Run("ProcessorKnownBrowserFingerprints", func(t *testing.T) { _TestProcessorKnownBrowserFingerprints(t, &testConfigFile)})
@@ -50,7 +51,8 @@ func TestProcessorConfigS3(t *testing.T) {
 		Loader:            s3Instance,
 	}
 	t.Run("New", func(t *testing.T) { _, err := mitmengine.NewProcessor(&testConfigS3); testutil.Ok(t, err) })
-	t.Run("Check", func(t *testing.T) { _TestProcessorCheck(t, &testConfigS3) })
+	t.Run("CheckSequential", func(t *testing.T) { _TestProcessorCheckSequential(t, &testConfigS3) })
+	t.Run("CheckConcurrent", func(t *testing.T) { _TestProcessorCheckConcurrent(t, &testConfigS3) })
 	t.Run("GetByUASignatureBrowser", func(t *testing.T) { _TestProcessorGetByUASignatureBrowser(t, &testConfigS3) })
 	t.Run("GetByRequestSignatureMitm", func(t *testing.T) { _TestProcessorGetByRequestSignatureMitm(t, &testConfigS3) })
 	//t.Run("ProcessorKnownBrowserFingerprints", func(t *testing.T) { _TestProcessorKnownBrowserFingerprints(t, &testConfigS3)})
@@ -121,7 +123,7 @@ func _TestProcessorKnownMitmFingerprints(t *testing.T, config *mitmengine.Config
 }
 
 // Check that all fields of the processing report match as expected
-func _TestProcessorCheck(t *testing.T, config *mitmengine.Config) {
+func _TestProcessorCheckSequential(t *testing.T, config *mitmengine.Config) {
 	var tests = []struct {
 		rawUa       string
 		fingerprint string
@@ -159,6 +161,62 @@ func _TestProcessorCheck(t *testing.T, config *mitmengine.Config) {
 	}
 }
 
+func _TestProcessorCheckConcurrent(t *testing.T, config *mitmengine.Config) {
+	type testParam struct {
+		rawUa       string
+		fingerprint string
+		out         mitmengine.Report
+	}
+	var tests = []testParam{
+		// Empty browser
+		//{"", "::::::", mitmengine.Report{Error: mitmengine.ErrorUnknownUserAgent}},
+		// Microsoft Edge -- real browser fingerprint
+		//{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134", "0303:c02c,c02b,c030,c02f,c024,c023,c028,c027,c00a,c009,c014,c013,9d,9c,3d,3c,35,2f,0a:00,05,0a,0b,0d,23,10,17,18,ff01:1d,17,18:00:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		// Chrome 70 -- real browser fingerprint
+		{"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36", "0303:0a,2f,35,9c,9d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9:00,05,0a,0b,0d,10,12,15,17,1b,23,2b,2d,33,7550,ff01:1d,17,18:00:*:grease", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36", "0303:0a,2f,35,9c,9d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9:00,05,0a,0b,0d,10,12,15,17,1b,23,2b,2d,33,7550,ff01:1d,17,18:00:*:grease", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36", "0303:0a,2f,35,9c,9d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9:00,05,0a,0b,0d,10,12,15,17,1b,23,2b,2d,33,7550,ff01:1d,17,18:00:*:grease", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		// Chrome 49 -- real browser fingerprint
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "303:0a,2f,33,35,39,9c,9e,ff,c009,c00a,c013,c014,c02b,c02f,cc13,cc14,cc15,cca8:0,5,a,b,d,10,12,15,17,23,3374,7550,ff01:17,18:0:*:", mitmengine.Report{BrowserSignatureMatch: fp.MatchPossible}},
+		// MITM
+		//{"Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko", "303:c02b,c02f,c023,c027,c00a,c009,c014,c013,3d,3c,35,2f,a,ff:0,b,a,d:e,d,19,b,c,18,9,a,16,17,8,6,7,14,15,4,5,12,13,1,2,3,f,10,11:0,1,2:host,x-bluecoat-via:", mitmengine.Report{BrowserSignatureMatch: fp.MatchImpossible}},
+	}
+	a, _ := mitmengine.NewProcessor(config)
+	for _, test := range tests {
+		go func(){
+			var userAgent ua.UserAgent
+			ua.ParseUserAgent(test.rawUa, &userAgent)
+			uaFingerprint := fp.UAFingerprint{
+				BrowserName:    int(userAgent.Browser.Name),
+				BrowserVersion: fp.UAVersion(userAgent.Browser.Version),
+				OSPlatform:     int(userAgent.OS.Platform),
+				OSName:         int(userAgent.OS.Name),
+				OSVersion:      fp.UAVersion(userAgent.OS.Version),
+				DeviceType:     int(userAgent.DeviceType),
+			}
+			fingerprint, err := fp.NewRequestFingerprint(test.fingerprint)
+			testutil.Ok(t, err)
+			actual := a.Check(uaFingerprint, test.rawUa, fingerprint)
+			testutil.Equals(t, test.out.Error, actual.Error)
+			testutil.Equals(t, test.out.BrowserSignatureMatch, actual.BrowserSignatureMatch)
+		}()
+	}
+}
+
+
 func _TestProcessorGetByUASignatureBrowser(t *testing.T, config *mitmengine.Config) {
 	file, err := mitmengine.LoadFile(config.BrowserFileName, config.Loader)
 	testutil.Ok(t, err)
@@ -192,7 +250,7 @@ func _TestProcessorGetByRequestSignatureMitm(t *testing.T, config *mitmengine.Co
 	}
 }
 
-func BenchmarkProcessorCheck(b *testing.B) {
+func BenchmarkProcessorCheckSequential(b *testing.B) {
 	testConfigFile := mitmengine.Config{
 		BrowserFileName:   filepath.Join("testdata", "mitmengine", "browser.txt"),
 		MitmFileName:      filepath.Join("testdata", "mitmengine", "mitm.txt"),
@@ -200,6 +258,19 @@ func BenchmarkProcessorCheck(b *testing.B) {
 	}
 	var t *testing.T
 	for n := 0; n < b.N; n++ {
-		_TestProcessorCheck(t, &testConfigFile)
+		_TestProcessorCheckSequential(t, &testConfigFile)
+	}
+}
+
+
+func BenchmarkProcessorCheckConcurrent(b *testing.B) {
+	testConfigFile := mitmengine.Config{
+		BrowserFileName:   filepath.Join("testdata", "mitmengine", "browser.txt"),
+		MitmFileName:      filepath.Join("testdata", "mitmengine", "mitm.txt"),
+		BadHeaderFileName: filepath.Join("testdata", "mitmengine", "badheader.txt"),
+	}
+	var t *testing.T
+	for n := 0; n < b.N; n++ {
+		_TestProcessorCheckConcurrent(t, &testConfigFile)
 	}
 }


### PR DESCRIPTION
This PR introduces use of [intsets](https://godoc.org/golang.org/x/tools/container/intsets), a golang package that implements a fast set implementation for sparse ints. 

Repeated trials on my local dev environment demonstrate that performance improvement is substantial (a 38% decrease from 19038614 ns/op to 11796146 ns/op), and there is also a decrease in memory usage (17% decrease from 1070.14MB to 891.50MB). These stats are included below.

Old master branch cpu and mem pprof output:
```
BenchmarkProcessorCheck-8   	     100	  19038614 ns/op
PASS
ok  	github.com/cloudflare/mitmengine	2.582s
Gabbis-Work-MacBook-3:mitmengine gabbifisher$ go tool pprof -top cpu.prof 
Type: cpu
Time: Dec 9, 2018 at 1:47pm (PST)
Duration: 2.56s, Total samples = 3.07s (119.80%)
Showing nodes accounting for 2.96s, 96.42% of 3.07s total
Dropped 54 nodes (cum <= 0.02s)
      flat  flat%   sum%        cum   cum%
     1.21s 39.41% 39.41%      1.21s 39.41%  syscall.Syscall
     0.53s 17.26% 56.68%      0.53s 17.26%  runtime.pthread_cond_wait
     0.15s  4.89% 61.56%      0.15s  4.89%  runtime.stkbucket
     0.14s  4.56% 66.12%      0.14s  4.56%  runtime.duffcopy
     0.13s  4.23% 70.36%      0.13s  4.23%  runtime.kevent
     0.11s  3.58% 73.94%      0.11s  3.58%  runtime.pthread_cond_signal
     0.07s  2.28% 76.22%      0.07s  2.28%  runtime.pthread_cond_timedwait_relative_np
     0.04s  1.30% 77.52%      0.07s  2.28%  runtime.findObject
     0.04s  1.30% 78.83%      0.05s  1.63%  runtime.greyobject
     0.04s  1.30% 80.13%      0.05s  1.63%  runtime.heapBitsSetType
     0.04s  1.30% 81.43%      0.31s 10.10%  runtime.mallocgc
     0.04s  1.30% 82.74%      0.04s  1.30%  runtime.mapiternext
     0.03s  0.98% 83.71%      0.03s  0.98%  runtime.mapaccess1_fast64
     0.03s  0.98% 84.69%      0.03s  0.98%  runtime.memmove
     0.03s  0.98% 85.67%      0.15s  4.89%  runtime.scanobject
     0.03s  0.98% 86.64%      0.03s  0.98%  runtime.usleep
     0.02s  0.65% 87.30%      0.40s 13.03%  github.com/cloudflare/mitmengine/db.Database.GetBy
     0.02s  0.65% 87.95%      0.02s  0.65%  runtime.(*gcBitsArena).tryAlloc (inline)
     0.02s  0.65% 88.60%      0.02s  0.65%  runtime.add (inline)
     0.02s  0.65% 89.25%      0.02s  0.65%  runtime.arenaIndex (inline)
     0.02s  0.65% 89.90%      0.03s  0.98%  runtime.lock
     0.02s  0.65% 90.55%      0.02s  0.65%  runtime.memclrNoHeapPointers
     0.02s  0.65% 91.21%      0.22s  7.17%  runtime.newobject
     0.02s  0.65% 91.86%      0.02s  0.65%  runtime.nextFreeFast (inline)
     0.02s  0.65% 92.51%      0.03s  0.98%  runtime.spanOf (inline)
     0.02s  0.65% 93.16%      0.03s  0.98%  runtime.sweepone
     0.01s  0.33% 93.49%      1.28s 41.69%  github.com/cloudflare/mitmengine/db.(*Database).Load
     0.01s  0.33% 93.81%      0.12s  3.91%  github.com/cloudflare/mitmengine/fputil.(*IntSignature).Parse
     0.01s  0.33% 94.14%      0.05s  1.63%  github.com/cloudflare/mitmengine/fputil.StringSet.Diff
     0.01s  0.33% 94.46%      0.03s  0.98%  runtime.(*mcentral).grow
     0.01s  0.33% 94.79%      0.02s  0.65%  runtime.casgstatus
     0.01s  0.33% 95.11%      0.03s  0.98%  runtime.evacuate_fast64
     0.01s  0.33% 95.44%      0.23s  7.49%  runtime.gcDrain
     0.01s  0.33% 95.77%      0.07s  2.28%  runtime.mapassign_fast64
     0.01s  0.33% 96.09%      0.02s  0.65%  runtime.mapiterinit
     0.01s  0.33% 96.42%      0.02s  0.65%  runtime.wbBufFlush1
         0     0% 96.42%      1.07s 34.85%  bufio.(*Scanner).Scan
         0     0% 96.42%      0.21s  6.84%  github.com/cloudflare/mitmengine.(*Processor).Check
         0     0% 96.42%      1.40s 45.60%  github.com/cloudflare/mitmengine.(*Processor).Load
         0     0% 96.42%      0.14s  4.56%  github.com/cloudflare/mitmengine.LoadFile
         0     0% 96.42%      1.40s 45.60%  github.com/cloudflare/mitmengine.NewProcessor
         0     0% 96.42%      0.19s  6.19%  github.com/cloudflare/mitmengine/db.(*Record).Parse
         0     0% 96.42%      0.22s  7.17%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint
         0     0% 96.42%      0.21s  6.84%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint.func1
         0     0% 96.42%      0.18s  5.86%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint
         0     0% 96.42%      0.06s  1.95%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint.func1
         0     0% 96.42%      1.28s 41.69%  github.com/cloudflare/mitmengine/db.NewDatabase
         0     0% 96.42%      0.13s  4.23%  github.com/cloudflare/mitmengine/fputil.(*RequestSignature).Parse
         0     0% 96.42%      0.03s  0.98%  github.com/cloudflare/mitmengine/fputil.(*StringSignature).Parse
         0     0% 96.42%      0.04s  1.30%  github.com/cloudflare/mitmengine/fputil.(*UASignature).Parse
         0     0% 96.42%      0.03s  0.98%  github.com/cloudflare/mitmengine/fputil.IntList.Set
         0     0% 96.42%      0.15s  4.89%  github.com/cloudflare/mitmengine/fputil.IntSet.Inter
         0     0% 96.42%      0.19s  6.19%  github.com/cloudflare/mitmengine/fputil.IntSignature.Match
         0     0% 96.42%      0.25s  8.14%  github.com/cloudflare/mitmengine/fputil.RequestSignature.Match
         0     0% 96.42%      0.26s  8.47%  github.com/cloudflare/mitmengine/fputil.RequestSignature.MatchMap
         0     0% 96.42%      0.06s  1.95%  github.com/cloudflare/mitmengine/fputil.StringSignature.Match
         0     0% 96.42%      0.02s  0.65%  github.com/cloudflare/mitmengine/fputil.UASignature.Match
         0     0% 96.42%      1.57s 51.14%  github.com/cloudflare/mitmengine_test.BenchmarkProcessorCheck
         0     0% 96.42%      0.02s  0.65%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func1
         0     0% 96.42%      0.02s  0.65%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func2
         0     0% 96.42%      0.17s  5.54%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func3
         0     0% 96.42%      0.11s  3.58%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func4
         0     0% 96.42%      1.59s 51.79%  github.com/cloudflare/mitmengine_test._TestProcessorCheck
         0     0% 96.42%      0.11s  3.58%  github.com/cloudflare/mitmengine_test._TestProcessorGetByRequestSignatureMitm
         0     0% 96.42%      0.17s  5.54%  github.com/cloudflare/mitmengine_test._TestProcessorGetByUASignatureBrowser
         0     0% 96.42%      1.07s 34.85%  internal/poll.(*FD).Read
         0     0% 96.42%      1.07s 34.85%  os.(*File).Read
         0     0% 96.42%      1.07s 34.85%  os.(*File).read
         0     0% 96.42%      0.14s  4.56%  os.Open
         0     0% 96.42%      0.14s  4.56%  os.OpenFile
         0     0% 96.42%      0.14s  4.56%  os.openFileNolog
         0     0% 96.42%      0.03s  0.98%  runtime.(*gcWork).balance
         0     0% 96.42%      0.03s  0.98%  runtime.(*mcache).nextFree
         0     0% 96.42%      0.03s  0.98%  runtime.(*mcache).nextFree.func1
         0     0% 96.42%      0.03s  0.98%  runtime.(*mcache).refill
         0     0% 96.42%      0.03s  0.98%  runtime.(*mcentral).cacheSpan
         0     0% 96.42%      0.03s  0.98%  runtime.bgsweep
         0     0% 96.42%      0.02s  0.65%  runtime.execute
         0     0% 96.42%      0.55s 17.92%  runtime.findrunnable
         0     0% 96.42%      0.06s  1.95%  runtime.forEachP
         0     0% 96.42%      0.22s  7.17%  runtime.gcBgMarkWorker
         0     0% 96.42%      0.22s  7.17%  runtime.gcBgMarkWorker.func2
         0     0% 96.42%      0.06s  1.95%  runtime.gcMarkDone.func1
         0     0% 96.42%      0.13s  4.23%  runtime.gcStart.func2
         0     0% 96.42%      0.02s  0.65%  runtime.gcWriteBarrier
         0     0% 96.42%      0.02s  0.65%  runtime.gentraceback
         0     0% 96.42%      0.08s  2.61%  runtime.gopreempt_m
         0     0% 96.42%      0.12s  3.91%  runtime.goschedImpl
         0     0% 96.42%      0.04s  1.30%  runtime.gosched_m
         0     0% 96.42%      0.03s  0.98%  runtime.gosweepone
         0     0% 96.42%      0.03s  0.98%  runtime.gosweepone.func1
         0     0% 96.42%      0.03s  0.98%  runtime.growWork_fast64
         0     0% 96.42%      0.02s  0.65%  runtime.growslice
         0     0% 96.42%      0.03s  0.98%  runtime.handoff
         0     0% 96.42%      0.16s  5.21%  runtime.mProf_Malloc
         0     0% 96.42%      0.05s  1.63%  runtime.makeBucketArray
         0     0% 96.42%      0.13s  4.23%  runtime.makemap
         0     0% 96.42%      0.09s  2.93%  runtime.makemap_small
         0     0% 96.42%      0.04s  1.30%  runtime.makeslice
         0     0% 96.42%      0.02s  0.65%  runtime.markroot
         0     0% 96.42%      0.63s 20.52%  runtime.mcall
         0     0% 96.42%      0.08s  2.61%  runtime.morestack
         0     0% 96.42%      0.22s  7.17%  runtime.mstart
         0     0% 96.42%      0.13s  4.23%  runtime.netpoll
         0     0% 96.42%      0.02s  0.65%  runtime.newMarkBits
         0     0% 96.42%      0.05s  1.63%  runtime.newarray
         0     0% 96.42%      0.08s  2.61%  runtime.newstack
         0     0% 96.42%      0.53s 17.26%  runtime.notesleep
         0     0% 96.42%      0.07s  2.28%  runtime.notetsleep
         0     0% 96.42%      0.07s  2.28%  runtime.notetsleep_internal
         0     0% 96.42%      0.12s  3.91%  runtime.notewakeup
         0     0% 96.42%      0.02s  0.65%  runtime.osyield
         0     0% 96.42%      0.59s 19.22%  runtime.park_m
         0     0% 96.42%      0.16s  5.21%  runtime.profilealloc
         0     0% 96.42%      0.07s  2.28%  runtime.resetspinning
         0     0% 96.42%      0.05s  1.63%  runtime.runSafePointFn
         0     0% 96.42%      0.70s 22.80%  runtime.schedule
         0     0% 96.42%      0.60s 19.54%  runtime.semasleep
         0     0% 96.42%      0.12s  3.91%  runtime.semawakeup
         0     0% 96.42%      0.13s  4.23%  runtime.startTheWorldWithSema
         0     0% 96.42%      0.07s  2.28%  runtime.startm
         0     0% 96.42%      0.54s 17.59%  runtime.stopm
         0     0% 96.42%      0.51s 16.61%  runtime.systemstack
         0     0% 96.42%      0.07s  2.28%  runtime.wakep
         0     0% 96.42%      0.02s  0.65%  runtime.wbBufFlush
         0     0% 96.42%      0.02s  0.65%  runtime.wbBufFlush.func1
         0     0% 96.42%      0.05s  1.63%  strings.Split
         0     0% 96.42%      0.05s  1.63%  strings.genSplit
         0     0% 96.42%      0.13s  4.23%  syscall.Open
         0     0% 96.42%      1.07s 34.85%  syscall.Read
         0     0% 96.42%      1.07s 34.85%  syscall.read
         0     0% 96.42%      1.55s 50.49%  testing.(*B).launch
         0     0% 96.42%      0.02s  0.65%  testing.(*B).run1.func1
         0     0% 96.42%      1.57s 51.14%  testing.(*B).runN
         0     0% 96.42%      0.32s 10.42%  testing.tRunner

Showing nodes accounting for 1058.10MB, 98.87% of 1070.14MB total
Dropped 39 nodes (cum <= 5.35MB)
      flat  flat%   sum%        cum   cum%
  467.15MB 43.65% 43.65%   573.20MB 53.56%  github.com/cloudflare/mitmengine/fputil.(*IntSignature).Parse
  167.56MB 15.66% 59.31%   167.56MB 15.66%  strings.genSplit
   82.50MB  7.71% 67.02%       83MB  7.76%  github.com/cloudflare/mitmengine/fputil.(*StringSignature).Parse
   77.02MB  7.20% 74.22%    77.02MB  7.20%  github.com/cloudflare/mitmengine/fputil.IntSet.Inter
   68.66MB  6.42% 80.63%    68.66MB  6.42%  github.com/cloudflare/mitmengine/db.(*Database).Add (inline)
   42.17MB  3.94% 84.57%    42.17MB  3.94%  regexp.(*bitState).reset
   39.01MB  3.65% 88.22%    39.01MB  3.65%  github.com/cloudflare/mitmengine/fputil.IntSet.Diff
   28.50MB  2.66% 90.88%    28.50MB  2.66%  github.com/cloudflare/mitmengine/fputil.StringSet.Diff
   28.01MB  2.62% 93.50%    28.01MB  2.62%  github.com/cloudflare/mitmengine/fputil.IntList.Set
   26.51MB  2.48% 95.98%    26.51MB  2.48%  bufio.(*Scanner).Text (inline)
      14MB  1.31% 97.29%       14MB  1.31%  github.com/cloudflare/mitmengine/fputil.StringSet.Inter
   10.50MB  0.98% 98.27%    10.50MB  0.98%  github.com/cloudflare/mitmengine/fputil.StringList.Set
    5.50MB  0.51% 98.78%   170.54MB 15.94%  github.com/cloudflare/mitmengine/fputil.RequestSignature.MatchMap
    0.50MB 0.047% 98.83%   809.38MB 75.63%  github.com/cloudflare/mitmengine.(*Processor).Load
    0.50MB 0.047% 98.87%   179.54MB 16.78%  github.com/cloudflare/mitmengine/db.Database.GetBy
         0     0% 98.87%   114.52MB 10.70%  github.com/cloudflare/mitmengine.(*Processor).Check
         0     0% 98.87%   809.38MB 75.63%  github.com/cloudflare/mitmengine.NewProcessor
         0     0% 98.87%   814.88MB 76.15%  github.com/cloudflare/mitmengine/db.(*Database).Load
         0     0% 98.87%   717.71MB 67.07%  github.com/cloudflare/mitmengine/db.(*Record).Parse
         0     0% 98.87%   147.54MB 13.79%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint
         0     0% 98.87%   147.54MB 13.79%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint.func1
         0     0% 98.87%       32MB  2.99%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint
         0     0% 98.87%    31.50MB  2.94%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint.func1
         0     0% 98.87%   814.88MB 76.15%  github.com/cloudflare/mitmengine/db.NewDatabase
         0     0% 98.87%     6.50MB  0.61%  github.com/cloudflare/mitmengine/fputil.(*MitmInfo).Parse
         0     0% 98.87%   640.71MB 59.87%  github.com/cloudflare/mitmengine/fputil.(*RequestSignature).Parse
         0     0% 98.87%       62MB  5.79%  github.com/cloudflare/mitmengine/fputil.(*UASignature).Parse
         0     0% 98.87%     6.50MB  0.61%  github.com/cloudflare/mitmengine/fputil.(*UAVersion).Parse
         0     0% 98.87%    14.50MB  1.35%  github.com/cloudflare/mitmengine/fputil.(*UAVersionSignature).Parse
         0     0% 98.87%   144.04MB 13.46%  github.com/cloudflare/mitmengine/fputil.IntSignature.Match
         0     0% 98.87%   169.54MB 15.84%  github.com/cloudflare/mitmengine/fputil.RequestSignature.Match
         0     0% 98.87%    52.50MB  4.91%  github.com/cloudflare/mitmengine/fputil.StringSignature.Match
         0     0% 98.87%    31.50MB  2.94%  github.com/cloudflare/mitmengine/fputil.UASignature.Match
         0     0% 98.87%   912.40MB 85.26%  github.com/cloudflare/mitmengine_test.BenchmarkProcessorCheck
         0     0% 98.87%     7.50MB   0.7%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func2
         0     0% 98.87%    65.56MB  6.13%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func3
         0     0% 98.87%    78.14MB  7.30%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func4
         0     0% 98.87%   919.91MB 85.96%  github.com/cloudflare/mitmengine_test._TestProcessorCheck
         0     0% 98.87%    78.14MB  7.30%  github.com/cloudflare/mitmengine_test._TestProcessorGetByRequestSignatureMitm
         0     0% 98.87%    65.56MB  6.13%  github.com/cloudflare/mitmengine_test._TestProcessorGetByUASignatureBrowser
         0     0% 98.87%    40.56MB  3.79%  github.com/cloudflare/mitmengine_test.uaSigToFin
         0     0% 98.87%    42.67MB  3.99%  regexp.(*Regexp).ReplaceAllString
         0     0% 98.87%    42.67MB  3.99%  regexp.(*Regexp).doExecute
         0     0% 98.87%    42.67MB  3.99%  regexp.(*Regexp).replaceAll
         0     0% 98.87%    42.17MB  3.94%  regexp.(*machine).backtrack
         0     0% 98.87%   159.56MB 14.91%  strings.Split
         0     0% 98.87%        8MB  0.75%  strings.SplitN
         0     0% 98.87%   902.90MB 84.37%  testing.(*B).launch
         0     0% 98.87%     9.50MB  0.89%  testing.(*B).run1.func1
         0     0% 98.87%   912.40MB 85.26%  testing.(*B).runN
         0     0% 98.87%   155.70MB 14.55%  testing.tRunner
```

New intset implementation pprof output!
```
Gabbis-Work-MacBook-3:mitmengine gabbifisher$ go test -cpuprofile cpu.prof -memprofile mem.prof -bench .
2018/12/09 21:31:45 WARNING: loading file "" produced error "open : no such file or directory"
2018/12/09 21:31:45 WARNING: loading file "" produced error "open : no such file or directory"
2018/12/09 21:31:45 WARNING: loading file "" produced error "open : no such file or directory"
goos: darwin
goarch: amd64
pkg: github.com/cloudflare/mitmengine
BenchmarkProcessorCheck-8   	     100	  11796146 ns/op
PASS
ok  	github.com/cloudflare/mitmengine	1.648s
Gabbis-Work-MacBook-3:mitmengine gabbifisher$ go tool pprof -top cpu.prof 
Type: cpu
Time: Dec 9, 2018 at 9:31pm (PST)
Duration: 1.63s, Total samples = 2.12s (129.95%)
Showing nodes accounting for 2.05s, 96.70% of 2.12s total
Dropped 44 nodes (cum <= 0.01s)
      flat  flat%   sum%        cum   cum%
     1.04s 49.06% 49.06%      1.04s 49.06%  syscall.Syscall
     0.34s 16.04% 65.09%      0.34s 16.04%  runtime.pthread_cond_wait
     0.16s  7.55% 72.64%      0.16s  7.55%  runtime.pthread_cond_signal
     0.11s  5.19% 77.83%      0.11s  5.19%  runtime.kevent
     0.09s  4.25% 82.08%      0.09s  4.25%  runtime.stkbucket
     0.08s  3.77% 85.85%      0.08s  3.77%  runtime.duffcopy
     0.07s  3.30% 89.15%      0.07s  3.30%  runtime.pthread_cond_timedwait_relative_np
     0.04s  1.89% 91.04%      0.04s  1.89%  runtime.findObject
     0.03s  1.42% 92.45%      0.03s  1.42%  runtime.mapiternext
     0.02s  0.94% 93.40%      0.02s  0.94%  runtime.memclrNoHeapPointers
     0.02s  0.94% 94.34%      0.02s  0.94%  runtime.procyield
     0.02s  0.94% 95.28%      0.02s  0.94%  strings.genSplit
     0.01s  0.47% 95.75%      0.06s  2.83%  github.com/cloudflare/mitmengine/fputil.(*IntSignature).Parse
     0.01s  0.47% 96.23%      0.06s  2.83%  github.com/cloudflare/mitmengine/fputil.RequestSignature.Match
     0.01s  0.47% 96.70%      0.02s  0.94%  runtime.gcAssistAlloc1
         0     0% 96.70%      0.88s 41.51%  bufio.(*Scanner).Scan
         0     0% 96.70%      0.06s  2.83%  github.com/cloudflare/mitmengine.(*Processor).Check
         0     0% 96.70%      1.11s 52.36%  github.com/cloudflare/mitmengine.(*Processor).Load
         0     0% 96.70%      0.16s  7.55%  github.com/cloudflare/mitmengine.LoadFile
         0     0% 96.70%      1.11s 52.36%  github.com/cloudflare/mitmengine.NewProcessor
         0     0% 96.70%      0.96s 45.28%  github.com/cloudflare/mitmengine/db.(*Database).Load
         0     0% 96.70%      0.08s  3.77%  github.com/cloudflare/mitmengine/db.(*Record).Parse
         0     0% 96.70%      0.18s  8.49%  github.com/cloudflare/mitmengine/db.Database.GetBy
         0     0% 96.70%      0.05s  2.36%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint
         0     0% 96.70%      0.05s  2.36%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint.func1
         0     0% 96.70%      0.13s  6.13%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint
         0     0% 96.70%      0.03s  1.42%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint.func1
         0     0% 96.70%      0.96s 45.28%  github.com/cloudflare/mitmengine/db.NewDatabase
         0     0% 96.70%      0.03s  1.42%  github.com/cloudflare/mitmengine/fputil.(*IntSet).Inter
         0     0% 96.70%      0.06s  2.83%  github.com/cloudflare/mitmengine/fputil.(*RequestSignature).Parse
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine/fputil.(*StringSignature).Parse
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine/fputil.(*UASignature).Parse
         0     0% 96.70%      0.05s  2.36%  github.com/cloudflare/mitmengine/fputil.IntSignature.Match
         0     0% 96.70%      0.05s  2.36%  github.com/cloudflare/mitmengine/fputil.RequestSignature.MatchMap
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine/fputil.StringSet.Diff
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine/fputil.StringSignature.Match
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine/fputil.UASignature.Match
         0     0% 96.70%      1.14s 53.77%  github.com/cloudflare/mitmengine_test.BenchmarkProcessorCheck
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func2
         0     0% 96.70%      0.15s  7.08%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func3
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func4
         0     0% 96.70%      1.16s 54.72%  github.com/cloudflare/mitmengine_test._TestProcessorCheck
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine_test._TestProcessorGetByRequestSignatureMitm
         0     0% 96.70%      0.15s  7.08%  github.com/cloudflare/mitmengine_test._TestProcessorGetByUASignatureBrowser
         0     0% 96.70%      0.02s  0.94%  github.com/cloudflare/mitmengine_test.uaSigToFin
         0     0% 96.70%      0.88s 41.51%  internal/poll.(*FD).Read
         0     0% 96.70%      0.88s 41.51%  os.(*File).Read
         0     0% 96.70%      0.88s 41.51%  os.(*File).read
         0     0% 96.70%      0.16s  7.55%  os.Open
         0     0% 96.70%      0.16s  7.55%  os.OpenFile
         0     0% 96.70%      0.16s  7.55%  os.openFileNolog
         0     0% 96.70%      0.02s  0.94%  runtime.(*mcache).nextFree
         0     0% 96.70%      0.02s  0.94%  runtime.(*mcache).nextFree.func1
         0     0% 96.70%      0.02s  0.94%  runtime.(*mcache).refill
         0     0% 96.70%      0.02s  0.94%  runtime.(*mcentral).cacheSpan
         0     0% 96.70%      0.02s  0.94%  runtime.(*mcentral).grow
         0     0% 96.70%      0.02s  0.94%  runtime.(*mheap).alloc
         0     0% 96.70%      0.35s 16.51%  runtime.findrunnable
         0     0% 96.70%      0.06s  2.83%  runtime.forEachP
         0     0% 96.70%      0.02s  0.94%  runtime.gcAssistAlloc
         0     0% 96.70%      0.02s  0.94%  runtime.gcAssistAlloc.func1
         0     0% 96.70%      0.03s  1.42%  runtime.gcBgMarkWorker
         0     0% 96.70%      0.03s  1.42%  runtime.gcBgMarkWorker.func2
         0     0% 96.70%      0.03s  1.42%  runtime.gcDrain
         0     0% 96.70%      0.06s  2.83%  runtime.gcMarkDone.func1
         0     0% 96.70%      0.11s  5.19%  runtime.gcStart.func2
         0     0% 96.70%      0.04s  1.89%  runtime.gcstopm
         0     0% 96.70%      0.08s  3.77%  runtime.gopreempt_m
         0     0% 96.70%      0.02s  0.94%  runtime.goready.func1
         0     0% 96.70%      0.08s  3.77%  runtime.goschedImpl
         0     0% 96.70%      0.02s  0.94%  runtime.gosweepone
         0     0% 96.70%      0.02s  0.94%  runtime.gosweepone.func1
         0     0% 96.70%      0.03s  1.42%  runtime.growslice
         0     0% 96.70%      0.03s  1.42%  runtime.lock
         0     0% 96.70%      0.09s  4.25%  runtime.mProf_Malloc
         0     0% 96.70%      0.02s  0.94%  runtime.makemap_small
         0     0% 96.70%      0.14s  6.60%  runtime.mallocgc
         0     0% 96.70%      0.44s 20.75%  runtime.mcall
         0     0% 96.70%      0.08s  3.77%  runtime.morestack
         0     0% 96.70%      0.21s  9.91%  runtime.mstart
         0     0% 96.70%      0.11s  5.19%  runtime.netpoll
         0     0% 96.70%      0.09s  4.25%  runtime.newobject
         0     0% 96.70%      0.08s  3.77%  runtime.newstack
         0     0% 96.70%      0.34s 16.04%  runtime.notesleep
         0     0% 96.70%      0.07s  3.30%  runtime.notetsleep
         0     0% 96.70%      0.07s  3.30%  runtime.notetsleep_internal
         0     0% 96.70%      0.17s  8.02%  runtime.notewakeup
         0     0% 96.70%      0.44s 20.75%  runtime.park_m
         0     0% 96.70%      0.09s  4.25%  runtime.profilealloc
         0     0% 96.70%      0.02s  0.94%  runtime.ready
         0     0% 96.70%      0.11s  5.19%  runtime.resetspinning
         0     0% 96.70%      0.04s  1.89%  runtime.scanobject
         0     0% 96.70%      0.50s 23.58%  runtime.schedule
         0     0% 96.70%      0.41s 19.34%  runtime.semasleep
         0     0% 96.70%      0.17s  8.02%  runtime.semawakeup
         0     0% 96.70%      0.11s  5.19%  runtime.startTheWorldWithSema
         0     0% 96.70%      0.13s  6.13%  runtime.startm
         0     0% 96.70%      0.34s 16.04%  runtime.stopm
         0     0% 96.70%      0.02s  0.94%  runtime.sweepone
         0     0% 96.70%      0.30s 14.15%  runtime.systemstack
         0     0% 96.70%      0.13s  6.13%  runtime.wakep
         0     0% 96.70%      0.02s  0.94%  strings.Split
         0     0% 96.70%      0.16s  7.55%  syscall.Open
         0     0% 96.70%      0.88s 41.51%  syscall.Read
         0     0% 96.70%      0.88s 41.51%  syscall.read
         0     0% 96.70%      1.15s 54.25%  testing.(*B).launch
         0     0% 96.70%      1.15s 54.25%  testing.(*B).runN
         0     0% 96.70%      0.20s  9.43%  testing.tRunner
Gabbis-Work-MacBook-3:mitmengine gabbifisher$ go tool pprof -top mem.prof 
Type: alloc_space
Time: Dec 9, 2018 at 9:31pm (PST)
Showing nodes accounting for 879.38MB, 98.64% of 891.50MB total
Dropped 51 nodes (cum <= 4.46MB)
      flat  flat%   sum%        cum   cum%
  292.05MB 32.76% 32.76%   425.12MB 47.69%  github.com/cloudflare/mitmengine/fputil.(*IntSignature).Parse
  179.57MB 20.14% 52.90%   179.57MB 20.14%  strings.genSplit
   92.18MB 10.34% 63.24%    92.18MB 10.34%  github.com/cloudflare/mitmengine/db.(*Database).Add (inline)
      91MB 10.21% 73.45%    91.50MB 10.26%  github.com/cloudflare/mitmengine/fputil.(*StringSignature).Parse
   54.56MB  6.12% 79.57%    54.56MB  6.12%  regexp.(*bitState).reset
   30.51MB  3.42% 82.99%    30.51MB  3.42%  bufio.(*Scanner).Text (inline)
   28.50MB  3.20% 86.19%       30MB  3.37%  github.com/cloudflare/mitmengine/fputil.(*IntSet).Inter
   26.50MB  2.97% 89.16%    26.50MB  2.97%  github.com/cloudflare/mitmengine/vendor/golang.org/x/tools/container/intsets.(*Sparse).insertBlockBefore
      24MB  2.69% 91.85%       24MB  2.69%  github.com/cloudflare/mitmengine/fputil.StringSet.Diff
   17.50MB  1.96% 93.82%    17.50MB  1.96%  github.com/cloudflare/mitmengine/fputil.StringList.Set
   14.50MB  1.63% 95.44%    14.50MB  1.63%  github.com/cloudflare/mitmengine/fputil.StringSet.Inter
      14MB  1.57% 97.01%    15.50MB  1.74%  github.com/cloudflare/mitmengine/fputil.(*IntSet).Diff
      10MB  1.12% 98.14%    13.50MB  1.51%  github.com/cloudflare/mitmengine/fputil.IntList.Set
    3.50MB  0.39% 98.53%    81.51MB  9.14%  github.com/cloudflare/mitmengine/fputil.RequestSignature.MatchMap
    0.50MB 0.056% 98.59%    55.56MB  6.23%  regexp.(*Regexp).ReplaceAllString
    0.50MB 0.056% 98.64%   107.01MB 12.00%  github.com/cloudflare/mitmengine/db.Database.GetBy
         0     0% 98.64%    55.50MB  6.23%  github.com/cloudflare/mitmengine.(*Processor).Check
         0     0% 98.64%   707.31MB 79.34%  github.com/cloudflare/mitmengine.(*Processor).Load
         0     0% 98.64%   707.31MB 79.34%  github.com/cloudflare/mitmengine.NewProcessor
         0     0% 98.64%   709.31MB 79.56%  github.com/cloudflare/mitmengine/db.(*Database).Load
         0     0% 98.64%   583.13MB 65.41%  github.com/cloudflare/mitmengine/db.(*Record).Parse
         0     0% 98.64%    70.50MB  7.91%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint
         0     0% 98.64%    70.50MB  7.91%  github.com/cloudflare/mitmengine/db.Database.GetByRequestFingerprint.func1
         0     0% 98.64%    36.50MB  4.09%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint
         0     0% 98.64%       36MB  4.04%  github.com/cloudflare/mitmengine/db.Database.GetByUAFingerprint.func1
         0     0% 98.64%   709.31MB 79.56%  github.com/cloudflare/mitmengine/db.NewDatabase
         0     0% 98.64%     6.50MB  0.73%  github.com/cloudflare/mitmengine/fputil.(*MitmInfo).Parse
         0     0% 98.64%   508.62MB 57.05%  github.com/cloudflare/mitmengine/fputil.(*RequestSignature).Parse
         0     0% 98.64%    62.50MB  7.01%  github.com/cloudflare/mitmengine/fputil.(*UASignature).Parse
         0     0% 98.64%     6.50MB  0.73%  github.com/cloudflare/mitmengine/fputil.(*UAVersion).Parse
         0     0% 98.64%    16.50MB  1.85%  github.com/cloudflare/mitmengine/fputil.(*UAVersionSignature).Parse
         0     0% 98.64%       59MB  6.62%  github.com/cloudflare/mitmengine/fputil.IntSignature.Match
         0     0% 98.64%    81.51MB  9.14%  github.com/cloudflare/mitmengine/fputil.RequestSignature.Match
         0     0% 98.64%       55MB  6.17%  github.com/cloudflare/mitmengine/fputil.StringSignature.Match
         0     0% 98.64%       36MB  4.04%  github.com/cloudflare/mitmengine/fputil.UASignature.Match
         0     0% 98.64%    23.50MB  2.64%  github.com/cloudflare/mitmengine/vendor/golang.org/x/tools/container/intsets.(*Sparse).Insert
         0     0% 98.64%   757.32MB 84.95%  github.com/cloudflare/mitmengine_test.BenchmarkProcessorCheck
         0     0% 98.64%        5MB  0.56%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func1
         0     0% 98.64%    73.92MB  8.29%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func3
         0     0% 98.64%    51.15MB  5.74%  github.com/cloudflare/mitmengine_test.TestProcessorConfigFile.func4
         0     0% 98.64%   758.32MB 85.06%  github.com/cloudflare/mitmengine_test._TestProcessorCheck
         0     0% 98.64%    51.15MB  5.74%  github.com/cloudflare/mitmengine_test._TestProcessorGetByRequestSignatureMitm
         0     0% 98.64%    73.92MB  8.29%  github.com/cloudflare/mitmengine_test._TestProcessorGetByUASignatureBrowser
         0     0% 98.64%     6.14MB  0.69%  github.com/cloudflare/mitmengine_test.reqSigToFin
         0     0% 98.64%    51.42MB  5.77%  github.com/cloudflare/mitmengine_test.uaSigToFin
         0     0% 98.64%    55.06MB  6.18%  regexp.(*Regexp).doExecute
         0     0% 98.64%    55.06MB  6.18%  regexp.(*Regexp).replaceAll
         0     0% 98.64%    54.56MB  6.12%  regexp.(*machine).backtrack
         0     0% 98.64%   169.57MB 19.02%  strings.Split
         0     0% 98.64%       10MB  1.12%  strings.SplitN
         0     0% 98.64%   750.32MB 84.16%  testing.(*B).launch
         0     0% 98.64%        7MB  0.79%  testing.(*B).run1.func1
         0     0% 98.64%   757.32MB 84.95%  testing.(*B).runN
         0     0% 98.64%   131.07MB 14.70%  testing.tRunner
```