### PR TITLE
Add environment variable parsing when no keys presented in s3cfg file

### DIFF
--- a/fputil/request_test.go
+++ b/fputil/request_test.go
@@ -249,7 +249,8 @@ func TestIntSignatureMatch(t *testing.T) {
 		testutil.Ok(t, err)
 		fingerprint, err := fp.NewIntList(test.in2)
 		testutil.Ok(t, err)
-		testutil.Equals(t, test.out, signature.Match(fingerprint))
+		match, _ := signature.Match(fingerprint)
+		testutil.Equals(t, test.out, match)
 	}
 }
 

--- a/loader/s3.go
+++ b/loader/s3.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -36,6 +37,14 @@ func NewS3Instance(configFileName string) (S3, error) {
 
 	accessKey := viper.GetString("AccessKey")
 	secretKey := viper.GetString("SecretKey")
+
+	// If keys not in config file, read from environment variables
+	if len(accessKey) == 0 {
+		accessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+	}
+	if len(secretKey) == 0 {
+		secretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	}
 
 	auth, err := aws.GetAuth(strings.TrimSpace(string(accessKey)), strings.TrimSpace(string(secretKey)), "", time.Time{})
 	if err != nil {

--- a/loader/s3cfg-template.toml
+++ b/loader/s3cfg-template.toml
@@ -1,8 +1,8 @@
 # These are the minimal fields required to read from an S3 instance.
 # Fill these fields in and then rename this file to s3cfg.toml, then this configuration will be automatically loaded
 # into mitmengine.
-AccessKey = ""
-SecretKey = ""
+AccessKey = "" #If you don't want to store this in a file, can also be read in from AWS_ACCESS_KEY_ID env var
+SecretKey = "" #If you don't want to store this in a file, can also be read in from AWS_SECRET_ACCESS_KEY env var
 S3Endpoint = ""
 S3BucketEndpoint = ""
 BucketName = ""


### PR DESCRIPTION
Tiny PR for adding environment variable parsing for S3 access and secret keys; this allows users to pass in secrets to mitmengine through environment variables, which allows us to keep secrets secret in our k8s and marathon deployments.