### PR TITLE
Small fixes to make it easier to try out the demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .GOPATH
 bin/
 build/
+vendor/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Quick Links:
 - [How to Contribute](#how-to-contribute)
 - [mergeDB utility](#mergedb-utility)
 
+## Requirements
+
+- Go
+- Wireshark 3.0.0 (`wireshark -v` to check)
+
 ## Signature and Fingerprints
 In this project, fingerprints map to concrete instantiations of an object, while signatures can represent multiple objects. We use this convention because a fingerprint is usually an inherent property of an object, while a signature can be chosen. In the same way, an actual client request seen by a server would have a fingerprint, while the software generating the request can choose it's own signature (e.g., by choosing which cipher suites it supports).
 
@@ -48,11 +53,11 @@ detect a mismatch. If the browser signatures are overly broad, we will also
 fail to detect interception.
 
 ### Production fingerprints
-The reference browser and MITM software fingerprints used in [MALCOLM](https://malcolm.cloudflare.com) can be found in `reference_fingerprints/mitmengine/`. 
+The reference browser and MITM software fingerprints used in [MALCOLM](https://malcolm.cloudflare.com) can be found in `reference_fingerprints/mitmengine/`.
 This set of fingerprints is a combination of what is pulled from the TLS Client Hello pcaps in `reference_fingerprints/pcaps/`, as well as the top 500 User Agents + TLS Client Hello
 pairs observed on Cloudflare's network and labeled with a high trustworthiness rating (that is, traffic corresponding to human and friendly bot activity).
 
-Ideally, we don't have to rely on reference fingerprints sampled from Cloudflare's network; instead, we would have a comprehensive 
+Ideally, we don't have to rely on reference fingerprints sampled from Cloudflare's network; instead, we would have a comprehensive
 set of pcaps to build our set of reference TLS Client Hellos. Interested in helping us build out our dataset? See how [you can contribute](#submit-a-pull-request)!
 
 ## API
@@ -62,7 +67,7 @@ headers. Alternatively, it can also specify a configuration file for reading the
 other source; right now, MITMEngine supports reading these files from Amazon S3 client-compatible databases (including
 Amazon S3 and Ceph). Additional file readers for databases (which we call "loaders") can be defined in the `loaders`
 package, and as long as new loaders implement the Loader interface, they should work with the rest of MITMEngine out of the
-box. 
+box.
 
 The intended entrypoint to the MITMEngine package is through the `Processor.Check` function, which takes a User Agent and client request fingerprint, and returns a mitm detection report. Additional API functions will be added in the future to allow for adding new signatures to a running process, for example.
 
@@ -91,7 +96,7 @@ The uaFingerprint has the following format:
 An example of how to parse User Agents into the format for uaFingerprint is in the `cmd/demo/main.go` file.
 
 ## Building and Testing
-To use MITMEngine, remember to pull in its dependencies. 
+To use MITMEngine, remember to pull in its dependencies.
 You'll likely want to run vendoring or gomod logic before running tests on MITMEngine.
 
 To test, run `make test` and to see code coverage, run `make cover`.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -16,11 +16,11 @@ import (
 )
 
 func main() {
-	browserFileName := flag.String("browser", filepath.Join("reference_fingerprintsta", "mitmengine", "browser.txt"), "File containing browser signatures")
-	mitmFileName := flag.String("mitm", filepath.Join("reference_fingerprintsta", "mitmengine", "mitm.txt"), "File containing mitm signatures")
-	badHeaderFileName := flag.String("badheader", filepath.Join("reference_fingerprintsta", "mitmengine", "badheader.txt"), "File containing non-browser (bad) HTTP headers")
-	handshakePcapFileName := flag.String("handshake", "handshake.pcap", "Pcap containing TLS Client Hello")
-	headerJsonFileName := flag.String("header", "header.json", "Json file containing HTTP headers")
+	browserFileName := flag.String("browser", filepath.Join("reference_fingerprints", "mitmengine", "browser.txt"), "File containing browser signatures")
+	mitmFileName := flag.String("mitm", filepath.Join("reference_fingerprints", "mitmengine", "mitm.txt"), "File containing mitm signatures")
+	badHeaderFileName := flag.String("badheader", filepath.Join("reference_fingerprints", "mitmengine", "badheader.txt"), "File containing non-browser (bad) HTTP headers")
+	handshakePcapFileName := flag.String("handshake", filepath.Join("reference_fingerprints", "pcaps", "misc", "ios5", "handshake.pcap"), "Pcap containing TLS Client Hello")
+	headerJsonFileName := flag.String("header", filepath.Join("reference_fingerprints", "pcaps", "middleboxes", "barracuda", "barracuda-chrome48", "header.json"), "Json file containing HTTP headers")
 	flag.Parse()
 
 	// Load config

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 	// Read in TLS Client Hello fingerprint
-	requestFingerprintString, err := exec.Command("scripts/pcap_to_request_fingerprint.py", *handshakePcapFileName).Output()
+	requestFingerprintString, err := exec.Command(filepath.Join("scripts", "pcap_to_request_fingerprint.py"), *handshakePcapFileName).Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
### "add requirements"

Was not obvious that wireshark or even wireshark 3.0.0 (latest) is required, doesn't work on old versions (kind of mentioned already in the README but not really).

### "join path instead of using / for potential windows compatibility"

At the very least, it keeps it a bit consistent with the rest of the file.

### "handle tsark command execution errors"

Instead of a generic "JSON parsing failed" error, print stderr from the tshark command.

### "fix default paths for demo arguments and working default paths for other demo arguments"

Also not obvious that the default paths are to non-existent files. And some paths had a probably old name in them.

I would understand that the defaults for `handshake.pcap`, `header.json` would be the ones in the current directory as it seems that's the way the program is probably used and tested so this change is just an hint at having a better behavior for those options, maybe having a clearer error would help.

### "ignore vendor/ directory"

It's probably in every go dev `.gitgnore_global` file, but I'm not a go dev and didn't have so it polluted quite a bit my working directory.

Anyway, thanks.

(This PR is not meant to be merged, maybe closer to a list of current issues I found while trying the demo)

(The trailing of white spaces is just a bonus offered by my `.vimrc` :) )